### PR TITLE
Remove unused imports

### DIFF
--- a/src/jellyplex/jellyfin.py
+++ b/src/jellyplex/jellyfin.py
@@ -1,8 +1,6 @@
 import logging
 import pathlib
 import re
-import shutil
-import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union

--- a/src/jellyplex/library.py
+++ b/src/jellyplex/library.py
@@ -1,7 +1,6 @@
 import logging
 import pathlib
 import re
-import shutil
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Generator, Optional, Set, Tuple

--- a/src/jellyplex/plex.py
+++ b/src/jellyplex/plex.py
@@ -1,11 +1,7 @@
 import logging
 import pathlib
 import re
-import shutil
-import sys
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union
+from typing import Dict, Generator, List, Optional, Set, Tuple
 
 from .library import (
     RESOLUTION_PATTERN,

--- a/src/jellyplex/sync.py
+++ b/src/jellyplex/sync.py
@@ -1,11 +1,8 @@
 import logging
 import pathlib
 import re
-import shutil
-import sys
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union
+from typing import Dict, Generator, List, Optional, Set, Tuple, Type
 
 from .library import (
     ACCEPTED_VIDEO_SUFFIXES,

--- a/tests/test_renaming_jellyfin_plex.py
+++ b/tests/test_renaming_jellyfin_plex.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import pytest
 
 import jellyplex as jp
-from jellyplex.library import MovieInfo, VideoInfo
 
 @pytest.fixture
 def jlib() -> jp.JellyfinLibrary:

--- a/tests/test_renaming_plex_jellyfin.py
+++ b/tests/test_renaming_plex_jellyfin.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import pytest
 
 import jellyplex as jp
-from jellyplex.library import MovieInfo, VideoInfo
 
 @pytest.fixture
 def jlib() -> jp.JellyfinLibrary:


### PR DESCRIPTION
## Summary
- clean up unused imports across code and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jellyplex')*

------
https://chatgpt.com/codex/tasks/task_e_68408ecc3fa88326b7f1cf818c416d2b