### PR TITLE
Add test helper for import path

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+


### PR DESCRIPTION
## Summary
- ensure tests import modules from `src` by adjusting `sys.path`
- remove README test instructions per feedback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68409b89234c8326acc16763f6d1de96